### PR TITLE
Generate new token if refresh token is expired

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "require-all": "^3.0.0"
   },
   "name": "shotgun-nodejs",
-  "version": "4.2.0",
+  "version": "4.2.5",
   "description": "Autodesk Shotgrid REST API library",
   "main": "src/index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "require-all": "^3.0.0"
   },
   "name": "shotgun-nodejs",
-  "version": "4.2.5",
+  "version": "4.2.1",
   "description": "Autodesk Shotgrid REST API library",
   "main": "src/index.js",
   "devDependencies": {

--- a/src/client.js
+++ b/src/client.js
@@ -118,9 +118,9 @@ class ShotgunApiClient {
 
 		let { token } = this;
 
-		if (!token || await this.tokenExpired(token['refresh_token'], 'refresh_token'))
+		if (!token || await this.tokenExpired(token['refresh_token']))
 			token = await this.connect();
-		else if (await this.tokenExpired(token['access_token'], 'access_token'))
+		else if (await this.tokenExpired(token['access_token']))
 			token = await this.refreshToken();
 
 		return `${token.token_type} ${token.access_token}`;

--- a/src/client.js
+++ b/src/client.js
@@ -111,7 +111,7 @@ class ShotgunApiClient {
 
 		let jwtPayload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
 
-		return (Date.now() / 1000) > jwtPayload['exp'];
+		return (Date.now() / 1000) > jwtPayload.exp;
 	}
 
 	async getAuthorizationHeader() {

--- a/src/client.js
+++ b/src/client.js
@@ -104,7 +104,7 @@ class ShotgunApiClient {
 		return body;
 	}
 
-	async tokenExpired(token) {
+	tokenExpired(token) {
 
 		if (!token)
 			return false;
@@ -118,9 +118,9 @@ class ShotgunApiClient {
 
 		let { token } = this;
 
-		if (!token || await this.tokenExpired(token['refresh_token']))
+		if (!token || this.tokenExpired(token.refresh_token))
 			token = await this.connect();
-		else if (await this.tokenExpired(token['access_token']))
+		else if (this.tokenExpired(token.access_token))
 			token = await this.refreshToken();
 
 		return `${token.token_type} ${token.access_token}`;

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,6 @@ const util = require('util');
 const { RequestError } = require('./error');
 
 const DEFAULT_API_BASE_PATH = '/api/v1';
-const REFRESH_EXPIRATION_WINDOW = 1000 * 60 * 3;
 const RETRY_COUNT = 2;
 
 class ShotgunApiClient {
@@ -17,7 +16,6 @@ class ShotgunApiClient {
 		this.siteUrl = siteUrl;
 		this.credentials = credentials;
 		this._token = null;
-		this.tokenExpirationTimestamp = null;
 		this.debug = debug;
 
 		if (apiBasePath && !apiBasePath.startsWith('/'))
@@ -32,7 +30,6 @@ class ShotgunApiClient {
 
 	set token(val) {
 		this._token = val;
-		this.tokenExpirationTimestamp = val.expires_in * 1000 + Date.now();
 	}
 
 	async connect(credentials = this.credentials) {
@@ -107,13 +104,23 @@ class ShotgunApiClient {
 		return body;
 	}
 
-	async getAuthorizationHeader() {
-
-		let { token, tokenExpirationTimestamp } = this;
+	async tokenExpired(token) {
 
 		if (!token)
+			return false;
+
+		let jwtPayload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+
+		return (Date.now() / 1000) > jwtPayload['exp'];
+	}
+
+	async getAuthorizationHeader() {
+
+		let { token } = this;
+
+		if (!token || await this.tokenExpired(token['refresh_token'], 'refresh_token'))
 			token = await this.connect();
-		else if (Date.now() + REFRESH_EXPIRATION_WINDOW > tokenExpirationTimestamp)
+		else if (await this.tokenExpired(token['access_token'], 'access_token'))
 			token = await this.refreshToken();
 
 		return `${token.token_type} ${token.access_token}`;


### PR DESCRIPTION
The refresh token grant allows for a new access token to be generated based on prior authentication. Refresh tokens are valid for 24 hours and generated with each new access token.

If an access token is not refreshed for 24h, the refresh token becomes stale; making it not possible to refresh the access token.
-  Add logic to check the token expiration and request a new access token if it cannot be refreshed. 